### PR TITLE
Expand the call area of the Data Definition dialog

### DIFF
--- a/omodsim/formmodsim.cpp
+++ b/omodsim/formmodsim.cpp
@@ -73,8 +73,6 @@ FormModSim::FormModSim(int id, ModbusMultiServer& server, QSharedPointer<DataSim
     connect(_dataSimulator.get(), &DataSimulator::simulationStarted, this, &FormModSim::on_simulationStarted);
     connect(_dataSimulator.get(), &DataSimulator::simulationStopped, this, &FormModSim::on_simulationStopped);
     connect(_dataSimulator.get(), &DataSimulator::dataSimulated, this, &FormModSim::on_dataSimulated);
-
-    ui->frameDataDefinition->installEventFilter(this);
 }
 
 ///
@@ -115,21 +113,17 @@ void FormModSim::closeEvent(QCloseEvent* event)
 }
 
 ///
-/// \brief FormModSim::eventFilter
-/// \param watched
+/// \brief FormModSim::mouseDoubleClickEvent
 /// \param event
 /// \return
 ///
-bool FormModSim::eventFilter(QObject* watched, QEvent* event)
+void FormModSim::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if (watched == ui->frameDataDefinition && event->type() == QEvent::MouseButtonDblClick) {
-        auto* me = static_cast<QMouseEvent*>(event);
-        if(me->pos().x() > ui->statisticWidget->geometry().right()) {
-            emit doubleClicked();
-            return true;
-        }
+    if(ui->frameDataDefinition->geometry().contains(event->pos())) {
+        emit doubleClicked();
     }
-    return QWidget::eventFilter(watched, event);
+
+    return QWidget::mouseDoubleClickEvent(event);
 }
 
 ///

--- a/omodsim/formmodsim.h
+++ b/omodsim/formmodsim.h
@@ -121,7 +121,7 @@ public:
 protected:
     void changeEvent(QEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
-    bool eventFilter(QObject* watched, QEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 public slots:
     void show();


### PR DESCRIPTION
Now, activate the data display settings dialog by double-clicking the left or right mouse button on any unoccupied space inside the registers window, similar to the register write dialog and register description editing dialog.

Fixes #66
