### PR TITLE
Add full window state saving

### DIFF
--- a/omodsim/mainwindow.cpp
+++ b/omodsim/mainwindow.cpp
@@ -1840,13 +1840,7 @@ void MainWindow::loadSettings()
 
     QSettings m(filepath, QSettings::IniFormat, this);
 
-    const auto geometry = m.value("WindowGeometry", this->geometry()).toRect();
-    setGeometry(geometry);
-
-    const bool isMaximized = m.value("WindowMaximized").toBool();
-    if(isMaximized) {
-        showMaximized();
-    }
+    restoreGeometry(m.value("WindowGeometry").toByteArray());
 
     const auto viewMode = (QMdiArea::ViewMode)qBound(0, m.value("ViewMode", QMdiArea::SubWindowView).toInt(), 1);
     ui->mdiArea->setViewMode(viewMode);
@@ -1901,6 +1895,8 @@ void MainWindow::loadSettings()
             }
         }
     }
+
+    restoreState(m.value("WindowState").toByteArray());
 }
 
 ///
@@ -1934,8 +1930,8 @@ void MainWindow::saveSettings()
     m.clear();
     m.sync();
 
-    m.setValue("WindowMaximized", isMaximized());
-    m.setValue("WindowGeometry", isMaximized()? normalGeometry() : geometry());
+    m.setValue("WindowGeometry", saveGeometry());
+    m.setValue("WindowState", saveState());
 
     const auto frm = currentMdiChild();
     if(frm) m.setValue("ActiveWindow", frm->windowTitle());


### PR DESCRIPTION
Saving and restoring of all window sizes and states (normal, minimized, and maximized) has been added, as well as the position of internal window elements, including toolbars.

Changing the type of the stored value `WindowGeometry` will not cause errors, it will simply be reset to the default. The `WindowMaximized` setting is restored directly using `WindowGeometry` and is no longer needed. Only `WindowMinimized` requires separate processing due to the specifics of displaying the main window when the program starts.

Fixes #69
