### PR TITLE
Improve the saving of internal MDI windows

### DIFF
--- a/omodsim/formmodsim.cpp
+++ b/omodsim/formmodsim.cpp
@@ -729,6 +729,34 @@ void FormModSim::setLogViewState(LogViewState state)
 }
 
 ///
+/// \brief FormModSim::parentGeometry
+/// \return
+///
+QRect FormModSim::parentGeometry() const
+{
+    auto wnd = parentWidget();
+    return (!wnd->isMaximized() && !wnd->isMinimized()) ? wnd->geometry() : _parentGeometry;
+}
+
+///
+/// \brief FormModSim::setParentGeometry
+/// \param geometry
+///
+void FormModSim::setParentGeometry(const QRect& geometry)
+{
+    if(geometry.isValid())
+    {
+        _parentGeometry = geometry;
+
+        auto wnd = parentWidget();
+        if(wnd->geometry() != geometry)
+        {
+            wnd->setGeometry(geometry);
+        }
+    }
+}
+
+///
 /// \brief FormModSim::show
 ///
 void FormModSim::show()

--- a/omodsim/mainwindow.cpp
+++ b/omodsim/mainwindow.cpp
@@ -176,6 +176,17 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* e)
         case QEvent::Close:
             _windowActionList->removeWindow(qobject_cast<QMdiSubWindow*>(obj));
         break;
+        case QEvent::Move:
+            if(auto wnd = qobject_cast<const QMdiSubWindow*>(obj))
+            {
+                if(auto frm = qobject_cast<FormModSim*>(wnd->widget()))
+                {
+                    if (!wnd->isMinimized() && !wnd->isMaximized())
+                    {
+                        frm->setParentGeometry(wnd->geometry());
+                    }
+                }
+            }
         break;
         default:
             qt_noop();


### PR DESCRIPTION
The position and state of internal application windows (i.e., registers windows) can now be saved and restored, including those that were maximized or minimized at the time of saving.
