### PR TITLE
Installer optimization

### DIFF
--- a/.github/workflows/build-installer-qt5-win32.yml
+++ b/.github/workflows/build-installer-qt5-win32.yml
@@ -100,6 +100,9 @@ jobs:
           "C:\Qt\${{ env.QT_VERSION }}\${{ env.CMAKE_COMPILER }}\bin\windeployqt.exe" ^
             "%CD%\${{ env.BUILD_DIR }}\${{ env.BUILD_TYPE }}\omodsim.exe" ^
             --release ^
+            --no-angle ^
+            --no-quick ^
+            --no-svg ^
             --no-opengl-sw ^
             --no-system-d3d-compiler ^
             --plugindir "%CD%\${{ env.BUILD_DIR }}\${{ env.BUILD_TYPE }}\plugins"

--- a/.github/workflows/build-installer-qt5-win64.yml
+++ b/.github/workflows/build-installer-qt5-win64.yml
@@ -99,6 +99,9 @@ jobs:
           "C:\Qt\${{ env.QT_VERSION }}\${{ env.CMAKE_COMPILER }}\bin\windeployqt.exe" ^
             "%CD%\${{ env.BUILD_DIR }}\${{ env.BUILD_TYPE }}\omodsim.exe" ^
             --release ^
+            --no-angle ^
+            --no-quick ^
+            --no-svg ^
             --no-opengl-sw ^
             --no-system-d3d-compiler ^
             --plugindir "%CD%\${{ env.BUILD_DIR }}\${{ env.BUILD_TYPE }}\plugins"

--- a/.github/workflows/build-installer-qt6-win64.yml
+++ b/.github/workflows/build-installer-qt6-win64.yml
@@ -95,9 +95,11 @@ jobs:
             "%CD%\${{ env.BUILD_DIR }}\${{ env.BUILD_TYPE }}\omodsim.exe" ^
             --release ^
             --no-opengl-sw ^
+            --no-system-d3d-compiler ^
+            --no-system-dxc-compiler ^
             --plugindir "%CD%\${{ env.BUILD_DIR }}\${{ env.BUILD_TYPE }}\plugins" ^
             --skip-plugin-types help,generic,networkinformation,qmltooling,tls ^
-            --exclude-plugins qsqlibase,qsqlmimer,qsqloci,qsqlodbc,qsqlpsql
+            --exclude-plugins qgif,qjpeg,qpdf,qsqlibase,qsqlmimer,qsqloci,qsqlodbc,qsqlpsql,qsvg,qsvgicon
         shell: cmd
 
       - name: Install NSIS

--- a/.nsis/installer-win32.nsi
+++ b/.nsis/installer-win32.nsi
@@ -23,11 +23,38 @@
   !define MUI_FINISHPAGE_RUN_TEXT "Launch ${NAME}"
   !define MUI_FINISHPAGE_RUN_CHECKED
 
+  !searchparse /noerrors ${VERSION} "" VERSIONMAJOR "." VERSIONMINOR "." VERSIONPATCH "." VERSIONBUILD
+  !ifndef VERSIONBUILD
+    !define VERSIONBUILD "0"
+  !endif
+  !ifndef VERSIONPATCH
+    !define VERSIONPATCH "0"
+    !searchparse ${VERSION} "" VERSIONMAJOR "." VERSIONMINOR "-"
+  !endif
+  !searchparse /file ${LICENSE_FILE} "Copyright " COPYRIGHT
+
 #--------------------------------
 # Variables
 
   Var /GLOBAL DISPLAYNAME
   Var RebootRequired
+
+#--------------------------------
+# General
+
+  Name "${NAME} v${VERSION} (x86)"
+  OutFile "${OUTPUT_FILE}"
+  InstallDir "$PROGRAMFILES\${NAME}"
+  RequestExecutionLevel admin
+  SetCompressor /SOLID lzma
+  SetCompressorDictSize 64
+  VIProductVersion "${VERSIONMAJOR}.${VERSIONMINOR}.${VERSIONPATCH}.${VERSIONBUILD}"
+  VIFileVersion    "${VERSIONMAJOR}.${VERSIONMINOR}.${VERSIONPATCH}.${VERSIONBUILD}"
+  VIAddVersionKey /LANG=0 "ProductVersion"   "${VERSION}"
+  VIAddVersionKey /LANG=0 "FileVersion"      "${VERSION}"
+  VIAddVersionKey /LANG=0 "ProductName"      "${NAME}"
+  VIAddVersionKey /LANG=0 "FileDescription"  "${NAME}"
+  VIAddVersionKey /LANG=0 "LegalCopyright"   "Copyright (c) ${COPYRIGHT}"
 
 #--------------------------------
 
@@ -53,14 +80,6 @@ Function un.onInit
 FunctionEnd
 
 #--------------------------------
-# General
-
-  Name "${NAME} v${VERSION} (x86)"
-  OutFile "${OUTPUT_FILE}"
-  InstallDir "$PROGRAMFILES\${NAME}"
-  RequestExecutionLevel admin
-
-#--------------------------------
 # Pages
   
   # Installer pages
@@ -81,7 +100,7 @@ FunctionEnd
 
   Section
     SetOutPath $INSTDIR
-    File /r "${BUILD_PATH}\*"
+    File /r /x bearer /x canbus /x qgif.dll /x qicns.dll /x qjpeg.dll /x qtga.dll /x qtiff.dll /x qwbmp.dll /x qwebp.dll /x qsqlodbc.dll /x qsqlpsql.dll "${BUILD_PATH}\*"
     WriteUninstaller $INSTDIR\uninstall.exe
   SectionEnd
 
@@ -109,6 +128,7 @@ FunctionEnd
  Section "Visual Studio Runtime"
     SetOutPath "$INSTDIR"
     ExecWait '"$INSTDIR\vc_redist.x86.exe" /install /quiet /norestart' $0
+    Delete "$TEMP\dd_vcredist*"
 
     ; 3010 = reboot required
     ${If} $0 == 3010

--- a/.nsis/installer-win64.nsi
+++ b/.nsis/installer-win64.nsi
@@ -21,6 +21,16 @@
   !define MUI_FINISHPAGE_RUN_TEXT "Launch ${NAME}"
   !define MUI_FINISHPAGE_RUN_CHECKED
 
+  !searchparse /noerrors ${VERSION} "" VERSIONMAJOR "." VERSIONMINOR "." VERSIONPATCH "." VERSIONBUILD
+  !ifndef VERSIONBUILD
+    !define VERSIONBUILD "0"
+  !endif
+  !ifndef VERSIONPATCH
+    !define VERSIONPATCH "0"
+    !searchparse ${VERSION} "" VERSIONMAJOR "." VERSIONMINOR "-"
+  !endif
+  !searchparse /file ${LICENSE_FILE} "Copyright " COPYRIGHT
+
 #--------------------------------
 # Variables
 
@@ -33,6 +43,15 @@
   OutFile "${OUTPUT_FILE}"
   InstallDir "$PROGRAMFILES64\${NAME}"
   RequestExecutionLevel admin
+  SetCompressor /SOLID lzma
+  SetCompressorDictSize 64
+  VIProductVersion "${VERSIONMAJOR}.${VERSIONMINOR}.${VERSIONPATCH}.${VERSIONBUILD}"
+  VIFileVersion    "${VERSIONMAJOR}.${VERSIONMINOR}.${VERSIONPATCH}.${VERSIONBUILD}"
+  VIAddVersionKey /LANG=0 "ProductVersion"   "${VERSION}"
+  VIAddVersionKey /LANG=0 "FileVersion"      "${VERSION}"
+  VIAddVersionKey /LANG=0 "ProductName"      "${NAME}"
+  VIAddVersionKey /LANG=0 "FileDescription"  "${NAME}"
+  VIAddVersionKey /LANG=0 "LegalCopyright"   "Copyright (c) ${COPYRIGHT}"
 
 #--------------------------------
 # Pages
@@ -55,7 +74,7 @@
 
   Section
     SetOutPath $INSTDIR
-    File /r "${BUILD_PATH}\*"
+    File /r /x bearer /x canbus /x qgif.dll /x qicns.dll /x qjpeg.dll /x qtga.dll /x qtiff.dll /x qwbmp.dll /x qwebp.dll /x qsqlodbc.dll /x qsqlpsql.dll "${BUILD_PATH}\*"
     WriteUninstaller $INSTDIR\uninstall.exe
   SectionEnd
 
@@ -83,6 +102,7 @@
  Section "Visual Studio Runtime"
     SetOutPath "$INSTDIR"
     ExecWait '"$INSTDIR\vc_redist.x64.exe" /install /quiet /norestart' $0
+    Delete "$TEMP\dd_vcredist*"
 
     ; 3010 = reboot required
     ${If} $0 == 3010


### PR DESCRIPTION
- Unused Qt libraries and plugins have been removed.
- Optimal distribution compression has been set.
- The `vc_redist` file and temporary files are now removed after installation.
- The undefined `VERSIONMAJOR` and `VERSIONMINOR` variables have been fixed, which led to the incorrect zeroed version being written to the Uninstaller section of the Windows registry.
- A version section has been added to the installer.

The distribution size has been reduced by ~7 MB.

🌟🔔🎁{ }🎄; Merry Christmas! 😎
