### PR TITLE
Add a Close button to the dialogs

### DIFF
--- a/omodsim/qfixedsizedialog.cpp
+++ b/omodsim/qfixedsizedialog.cpp
@@ -8,9 +8,6 @@
 QFixedSizeDialog::QFixedSizeDialog(QWidget *parent, Qt::WindowFlags f)
     :QDialog(parent, f)
 {
-    setWindowFlags(Qt::Dialog |
-                   Qt::CustomizeWindowHint |
-                   Qt::WindowTitleHint);
     setWindowModality(Qt::WindowModal);
 }
 

--- a/omodsim/qfixedsizedialog.h
+++ b/omodsim/qfixedsizedialog.h
@@ -11,7 +11,11 @@ class QFixedSizeDialog : public QDialog
     Q_OBJECT
 
 public:
-    QFixedSizeDialog(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    QFixedSizeDialog(QWidget *parent = nullptr, Qt::WindowFlags f =
+                     Qt::Dialog |
+                     Qt::CustomizeWindowHint |
+                     Qt::WindowCloseButtonHint |
+                     Qt::WindowTitleHint);
 
 protected:
     void showEvent(QShowEvent* e) override;


### PR DESCRIPTION
This patch restores the system button that closes dialog boxes, bringing the user experience back to the standard Windows interface.

Current look:
<img width="292" height="218" alt="omodsim_2025-12-26_20-15-50" src="https://github.com/user-attachments/assets/5cdb261c-817e-4a59-9115-c61da92b3fd0" />

New look:
<img width="292" height="218" alt="omodsim_2025-12-26_20-15-10" src="https://github.com/user-attachments/assets/3148a6e9-b099-4e9f-9d56-bfac4bbbf95b" />
