### PR TITLE
🚀 Optimize the creation and display of the register window.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,6 +141,7 @@ set(SOURCES
     controls/simulationmodecombobox.cpp
     controls/statisticwidget.cpp
     controls/transpscrollarea.cpp
+    datadelegate.cpp
     datasimulator.cpp
     dialogs/dialogautosimulation.cpp
     dialogs/dialogcoilsimulation.cpp
@@ -225,6 +226,7 @@ set(HEADERS
     controls/simulationmodecombobox.h
     controls/statisticwidget.h
     controls/transpscrollarea.h
+    datadelegate.h
     datasimulator.h
     dialogs/dialogautosimulation.h
     dialogs/dialogcoilsimulation.h

--- a/src/controls/outputwidget.cpp
+++ b/src/controls/outputwidget.cpp
@@ -4,7 +4,7 @@
 #include <QInputDialog>
 #include "fontutils.h"
 #include "formatutils.h"
-#include "htmldelegate.h"
+#include "datadelegate.h"
 #include "outputwidget.h"
 #include "ui_outputwidget.h"
 
@@ -42,33 +42,6 @@ const int ValueRole = Qt::UserRole + 6;
 /// \brief ColorRole
 ///
 const int ColorRole = Qt::UserRole + 7;
-
-///
-/// \brief htmlPad
-/// \param count
-/// \return
-///
-QString htmlPad(int count)
-{
-    return QString("&nbsp;").repeated(count);
-}
-
-///
-/// \brief normalizeHtml
-/// \param s
-/// \return
-///
-QString normalizeHtml(const QString& s)
-{
-    QString out = s;
-    out.replace("&", "&amp;");
-    out.replace("<", "&lt;");
-    out.replace(">", "&gt;");
-    out.replace("\"", "&quot;");
-    out.replace("'", "&#39;");
-    out.replace(" ", "&nbsp;");
-    return out;
-}
 
 ///
 /// \brief emptyPixmap
@@ -131,31 +104,29 @@ QVariant OutputListModel::data(const QModelIndex& index, int role) const
     {
         case Qt::DisplayRole:
         {
-            const auto fg = itemData.FgColor.isValid() ? itemData.FgColor : _parentWidget->foregroundColor();
-            const auto bg = itemData.BgColor.isValid() ? itemData.BgColor : _parentWidget->backgroundColor();
-
-            const QString base = QString("%1: %2").arg(addrStr, itemData.ValueStr);
-            const int targetLen = base.length() + _columnsDistance;
-
-            QString descr = itemData.Description;
-            if (!descr.isEmpty())
+            QString descr;
+            if (!itemData.Description.isEmpty())
             {
-                const QString prefix = "; ";
-                const int freeSpace = targetLen - (base.length() + prefix.length());
-
+                const auto freeSpace = _columnsDistance - 2;
                 if (freeSpace > 0)
                 {
-                    if (descr.length() > freeSpace)
-                        descr = descr.left(freeSpace - 4) + "...";
-
-                    descr = prefix + descr;
+                    descr = QStringLiteral("; ");
+                    if (itemData.Description.length() > freeSpace)
+                    {
+                        if (freeSpace > 3)
+                        {
+                            descr += itemData.Description.left(freeSpace - 3);
+                            descr += QStringLiteral("...");
+                        }
+                    }
+                    else
+                    {
+                        descr += itemData.Description;
+                    }
                 }
             }
-
-            const int pad = targetLen - (base.length() + descr.length());
-            return QString(
-                       "<span style=\"background-color:%1; color:%2\">%3</span><span>%4%5</span>"
-                       ).arg(bg.name(), fg.name(), normalizeHtml(base), normalizeHtml(descr), (pad > 0) ? htmlPad(pad) : "");
+            const auto pad = _columnsDistance - descr.length();
+            return addrStr + QStringLiteral(": ") + itemData.ValueStr + descr + QStringLiteral(" ").repeated(pad);
         }
 
         case CaptureRole:
@@ -452,7 +423,7 @@ OutputWidget::OutputWidget(QWidget *parent) :
     ui->setupUi(this);
     ui->stackedWidget->setCurrentIndex(0);
     ui->listView->setModel(_listModel.get());
-    ui->listView->setItemDelegate(new HtmlDelegate(this));
+    ui->listView->setItemDelegate(new DataDelegate( this ));
     ui->labelStatus->setAutoFillBackground(true);
 
     setFont(defaultMonospaceFont());

--- a/src/datadelegate.cpp
+++ b/src/datadelegate.cpp
@@ -1,0 +1,36 @@
+#include <QApplication>
+#include <QPainter>
+#include <QStyleOptionViewItem>
+#include "datadelegate.h"
+
+///
+/// \brief DataDelegate::paint
+/// \param painter
+/// \param option
+/// \param index
+///
+void DataDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    const auto color = index.data(Qt::UserRole + 7).value<QColor>();
+    if ( color.isValid() )
+    {
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+
+        auto style = opt.widget ? opt.widget->style() : QApplication::style();
+        auto text = opt.text.trimmed();
+        const auto descr_index = text.indexOf(';');
+        if (descr_index > 0)
+        {
+            text = text.left(descr_index);
+        }
+
+        QFontMetrics fm(opt.font);
+        auto rect = style->subElementRect(QStyle::SE_ItemViewItemText, &opt, opt.widget);
+        rect.setWidth(style->itemTextRect(fm, opt.rect, opt.displayAlignment, true, text).width());
+        rect.adjust(2, 1, 2, -1);
+        painter->fillRect(rect, color);
+    }
+
+    QStyledItemDelegate::paint(painter, option, index);
+}

--- a/src/datadelegate.h
+++ b/src/datadelegate.h
@@ -1,0 +1,18 @@
+#ifndef DATADELEGATE_H
+#define DATADELEGATE_H
+
+#include <QStyledItemDelegate>
+
+///
+/// \brief The DataDelegate class
+///
+class DataDelegate : public QStyledItemDelegate
+{
+public:
+    explicit DataDelegate(QObject* parent = nullptr) : QStyledItemDelegate(parent) {}
+
+protected:
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+};
+
+#endif // DATADELEGATE_H

--- a/src/formmodsim.cpp
+++ b/src/formmodsim.cpp
@@ -54,7 +54,9 @@ FormModSim::FormModSim(int id, ModbusMultiServer& server, QSharedPointer<DataSim
     ui->comboBoxAddressBase->setCurrentAddressBase(AddressBase::Base1);
     ui->comboBoxModbusPointType->setCurrentPointType(QModbusDataUnit::HoldingRegisters);
 
-    onDefinitionChanged();
+    connect(this, &FormModSim::definitionChanged, &FormModSim::onDefinitionChanged);
+    emit definitionChanged();
+
     ui->outputWidget->setFocus();
     connect(ui->outputWidget, &OutputWidget::startTextCaptureError, this, &FormModSim::captureError);
     connect(ui->scriptControl, &JScriptControl::helpContext, this, &FormModSim::helpContextRequested);
@@ -222,7 +224,7 @@ void FormModSim::setDisplayDefinition(const DisplayDefinition& dd)
     setScriptSettings(dd.ScriptCfg);
     setDisplayHexAddresses(dd.HexAddress);
 
-    onDefinitionChanged();
+    emit definitionChanged();
 }
 
 ///
@@ -859,7 +861,7 @@ void FormModSim::on_lineEditAddress_valueChanged(const QVariant&)
         ui->lineEditLength->update();
     }
 
-    onDefinitionChanged();
+   emit definitionChanged();
 }
 
 ///
@@ -867,7 +869,7 @@ void FormModSim::on_lineEditAddress_valueChanged(const QVariant&)
 ///
 void FormModSim::on_lineEditLength_valueChanged(const QVariant&)
 {
-    onDefinitionChanged();
+    emit definitionChanged();
 }
 
 ///
@@ -878,7 +880,7 @@ void FormModSim::on_lineEditDeviceId_valueChanged(const QVariant& oldValue, cons
     _mbMultiServer.removeDeviceId(oldValue.toInt());
     _mbMultiServer.addDeviceId(newValue.toInt());
 
-    onDefinitionChanged();
+    emit definitionChanged();
 }
 
 ///
@@ -898,7 +900,7 @@ void FormModSim::on_comboBoxAddressBase_addressBaseChanged(AddressBase base)
 ///
 void FormModSim::on_comboBoxModbusPointType_pointTypeChanged(QModbusDataUnit::RegisterType type)
 {
-    onDefinitionChanged();
+    emit definitionChanged();
     emit pointTypeChanged(type);
 }
 

--- a/src/formmodsim.h
+++ b/src/formmodsim.h
@@ -150,6 +150,7 @@ signals:
     void helpContextRequested(const QString& helpKey);
     void byteOrderChanged(ByteOrder);
     void codepageChanged(const QString&);
+    void definitionChanged();
     void pointTypeChanged(QModbusDataUnit::RegisterType);
     void displayModeChanged(DisplayMode mode);
     void scriptSettingsChanged(const ScriptSettings&);


### PR DESCRIPTION
Unnecessary updates when creating a window have been eliminated (from 4 to 1).

Window display has been accelerated (hundreds of times) by eliminating the unnecessary use of HTML elements for text output. Previously, when displaying the text of each element of the register list, an HTML document was created, rendered, and deleted, and this was done twice: once to measure the size of the element and once to display it. This led to graphic flickering and jerky window resizing.

Fixed incorrect alignment of the register description text.

Fixes #89.
