### PR TITLE
Fix loading the register type from the XML file.

### DIFF
--- a/src/displaydefinition.h
+++ b/src/displaydefinition.h
@@ -5,6 +5,7 @@
 #include <QModbusDataUnit>
 #include <QXmlStreamWriter>
 #include "modbuslimits.h"
+#include "modbusserver.h"
 #include "scriptsettings.h"
 
 ///

--- a/src/enums.h
+++ b/src/enums.h
@@ -8,6 +8,7 @@
 template<typename Enum>
 struct EnumStrings {
     static const QMap<Enum, QString>& mapping() {
+        static_assert(false, "Use DECLARE_ENUM_STRINGS() macro to define: " __FUNCTION__);
         static const QMap<Enum, QString> map;
         return map;
     }


### PR DESCRIPTION
Due to a change in the order of header inclusion, the `EnumStrings` template specialization is no longer selected for the `QModbusDataUnit::RegisterType` type, which results in the use of an empty map of numerical values of register types and their names, i.e., when loading, all types are reset to “Input Status”.

A prohibition on using the `EnumStrings` template without specialization has also been added so that such errors are detected at the compilation stage.