### PR TITLE
Fix loading descriptions and colors.

### DIFF
--- a/src/controls/outputwidget.h
+++ b/src/controls/outputwidget.h
@@ -366,25 +366,26 @@ inline QXmlStreamReader& operator>>(QXmlStreamReader& in, AddressDescriptionMap2
         {
             const auto attributes = in.attributes();
             bool ok;
-            const auto device_id = static_cast<quint8>(attributes.value("DeviceId").toUShort(&ok));
+            auto device_id = static_cast<quint8>(attributes.value("DeviceId").toUShort(&ok));
+            if(!ok)
+            {
+                device_id = 0;
+            }
+            auto type = static_cast<QModbusDataUnit::RegisterType>(attributes.value("Type").toInt(&ok));
+            if(!ok)
+            {
+                type = QModbusDataUnit::RegisterType::Invalid;
+            }
+            const auto address = attributes.value("Address").toUShort(&ok);
             if(ok)
             {
-                const auto type = static_cast<QModbusDataUnit::RegisterType>(attributes.value("Type").toInt(&ok));
-                if(ok)
+                skip = false;
+                const auto value = in.readElementText(QXmlStreamReader::IncludeChildElements);
+                if(!value.isEmpty())
                 {
-                    const auto address = attributes.value("Address").toUShort(&ok);
-                    if(ok)
-                    {
-                        skip = false;
-                        const auto value = in.readElementText(QXmlStreamReader::IncludeChildElements);
-                        if(!value.isEmpty())
-                        {
-                            map.insert( { device_id, type, address }, value );
-                        }
-                    }
+                    map.insert( { device_id, type, address }, value );
                 }
             }
-
         }
         if(skip)
         {

--- a/src/formmodsim.h
+++ b/src/formmodsim.h
@@ -256,24 +256,16 @@ inline QSettings& operator >>(QSettings& in, FormModSim* frm)
 
     in >> frm->scriptControl();
 
+    AddressDescriptionMap2 descriptionMap;
     if(version >= QVersionNumber(1, 15))
     {
-        AddressDescriptionMap2 map;
-        in >> map;
-        for(auto it = map.cbegin(); it != map.cend(); ++it)
-        {
-            frm->setDescription(it.key().DeviceId, it.key().Type, it.key().Address, it.value());
-        }
+        in >> descriptionMap;
     }
 
+    AddressColorMap colorMap;
     if(version >= QVersionNumber(1, 15))
     {
-        AddressColorMap map;
-        in >> map;
-        for(auto it = map.cbegin(); it != map.cend(); ++it)
-        {
-            frm->setColor(it.key().DeviceId, it.key().Type, it.key().Address, it.value());
-        }
+        in >> colorMap;
     }
 
     bool isMinimized;
@@ -305,6 +297,15 @@ inline QSettings& operator >>(QSettings& in, FormModSim* frm)
 
     frm->setDisplayHexAddresses(in.value("DisplayHexAddresses").toBool());
     frm->setCodepage(in.value("Codepage").toString());
+
+    for(auto it = descriptionMap.cbegin(); it != descriptionMap.cend(); ++it)
+    {
+        frm->setDescription(it.key().DeviceId, it.key().Type, it.key().Address, it.value());
+    }
+    for(auto it = colorMap.cbegin(); it != colorMap.cend(); ++it)
+    {
+        frm->setColor(it.key().DeviceId, it.key().Type, it.key().Address, it.value());
+    }
 
     if(displayDefinition.ScriptCfg.RunOnStartup) {
         frm->runScript();
@@ -583,7 +584,9 @@ inline QXmlStreamReader& operator >>(QXmlStreamReader& xml, FormModSim* frm)
                 xml >> map;
                 for(auto it = map.cbegin(); it != map.cend(); ++it)
                 {
-                    frm->setDescription(it.key().DeviceId, it.key().Type, it.key().Address, it.value());
+                    const auto device_id = it.key().DeviceId;
+                    const auto type = it.key().Type;
+                    frm->setDescription(device_id ? device_id : dd.DeviceId, type ? type : dd.PointType, it.key().Address, it.value());
                 }
             }
             else if (xml.name() == QLatin1String("AddressColorMap")) {
@@ -591,7 +594,9 @@ inline QXmlStreamReader& operator >>(QXmlStreamReader& xml, FormModSim* frm)
                 xml >> map;
                 for(auto it = map.cbegin(); it != map.cend(); ++it)
                 {
-                    frm->setColor(it.key().DeviceId, it.key().Type, it.key().Address, it.value());
+                    const auto device_id = it.key().DeviceId;
+                    const auto type = it.key().Type;
+                    frm->setColor(device_id ? device_id : dd.DeviceId, type ? type : dd.PointType, it.key().Address, it.value());
                 }
             }
             else if (xml.name() == QLatin1String("ModbusDataUnit")) {


### PR DESCRIPTION
- For INI configuration files with “DeviceID” other than 1.
- For XML configuration files with omitted “DeviceId” and “Type” attributes in files saved in the previous version of the program.
