### PR TITLE
Fix the encoding of the “●” character in the status bar.

### DIFF
--- a/src/controls/mainstatusbar.cpp
+++ b/src/controls/mainstatusbar.cpp
@@ -107,7 +107,7 @@ void MainStatusBar::changeEvent(QEvent* event)
 ///
 void MainStatusBar::updateConnectionInfo(QLabel* label, const ConnectionDetails& cd)
 {
-    const QString dot = QStringLiteral("<span style='color:#22c55e; font-size:10px;'>\u25CF</span>&nbsp;");
+    const QString dot = QStringLiteral("<span style='color:#22c55e; font-size:10px;'>&#x25CF;</span>&nbsp;");
     switch(cd.Type)
     {
         case ConnectionType::Tcp:


### PR DESCRIPTION
Some compilers do not support UTF-8 encoding by default (e.g., MSVC), so a warning about incorrect encoding of the “●” character (0x25CF) is issued, and the character “?” is displayed instead.

In our case, it is better to use HTML encoding, i.e. `&#x25CF;`, so as not to depend on the encoding of the source file.