### PR TITLE
Remove the insignificant zeros for non-data fields.

### DIFF
--- a/src/formmodsim.cpp
+++ b/src/formmodsim.cpp
@@ -35,7 +35,6 @@ FormModSim::FormModSim(int id, ModbusMultiServer& server, QSharedPointer<DataSim
 
     ui->lineEditDeviceId->setInputRange(ModbusLimits::slaveRange());
     ui->lineEditDeviceId->setValue(1);
-    ui->lineEditDeviceId->setLeadingZeroes(true);
     ui->lineEditDeviceId->setHexButtonVisible(true);
     server.addDeviceId(ui->lineEditDeviceId->value<int>());
 
@@ -45,7 +44,6 @@ FormModSim::FormModSim(int id, ModbusMultiServer& server, QSharedPointer<DataSim
 
     const auto mbDefs = _mbMultiServer.getModbusDefinitions();
 
-    ui->lineEditAddress->setLeadingZeroes(true);
     ui->lineEditAddress->setInputRange(ModbusLimits::addressRange(mbDefs.AddrSpace, true));
     ui->lineEditAddress->setValue(0);
     ui->lineEditAddress->setHexButtonVisible(true);
@@ -183,7 +181,7 @@ DisplayDefinition FormModSim::displayDefinition() const
     dd.HexViewLength   = ui->lineEditLength->hexView();
     dd.AddrSpace = _mbMultiServer.getModbusDefinitions().AddrSpace;
     dd.DataViewColumnsDistance = ui->outputWidget->dataViewColumnsDistance();
-    dd.LeadingZeros = ui->lineEditDeviceId->leadingZeroes();
+    dd.LeadingZeros = _leadingZeros;
     dd.ScriptCfg = _scriptSettings;
 
     return dd;
@@ -200,7 +198,6 @@ void FormModSim::setDisplayDefinition(const DisplayDefinition& dd)
 
     const auto defs = _mbMultiServer.getModbusDefinitions();
 
-    ui->lineEditDeviceId->setLeadingZeroes(dd.LeadingZeros);
     ui->lineEditDeviceId->setValue(dd.DeviceId);
 
     ui->comboBoxAddressBase->blockSignals(true);
@@ -208,13 +205,11 @@ void FormModSim::setDisplayDefinition(const DisplayDefinition& dd)
     ui->comboBoxAddressBase->blockSignals(false);
 
     ui->lineEditAddress->blockSignals(true);
-    ui->lineEditAddress->setLeadingZeroes(dd.LeadingZeros);
     ui->lineEditAddress->setInputRange(ModbusLimits::addressRange(defs.AddrSpace, dd.ZeroBasedAddress));
     ui->lineEditAddress->setValue(dd.PointAddress);
     ui->lineEditAddress->blockSignals(false);
 
     ui->lineEditLength->blockSignals(true);
-    ui->lineEditLength->setLeadingZeroes(dd.LeadingZeros);
     ui->lineEditLength->setInputRange(ModbusLimits::lengthRange(dd.PointAddress, dd.ZeroBasedAddress, defs.AddrSpace));
     ui->lineEditLength->setValue(dd.Length);
     ui->lineEditLength->blockSignals(false);
@@ -228,6 +223,7 @@ void FormModSim::setDisplayDefinition(const DisplayDefinition& dd)
     ui->outputWidget->setAutosctollLogView(dd.AutoscrollLog);
 
     _verboseLogging = dd.VerboseLogging;
+    _leadingZeros = dd.LeadingZeros;
 
     setScriptSettings(dd.ScriptCfg);
     setDisplayHexAddresses(dd.HexAddress);

--- a/src/formmodsim.h
+++ b/src/formmodsim.h
@@ -196,6 +196,7 @@ private:
     int _formId;
     QString _filename;
     bool _verboseLogging;
+    bool _leadingZeros = true;
     ScriptSettings _scriptSettings;
     ModbusMultiServer& _mbMultiServer;
     QSharedPointer<DataSimulator> _dataSimulator;


### PR DESCRIPTION
In the register window, the address and length input fields have insignificant zeros on the left, which is confusing because this is how numbers are represented in the octal number system.

This happens because the leading zeros display setting (enabled by default) is applied not only to the register map, but also to the address, length, and node number input fields for some reason.

The `FormModSim::_leadingZeros` class variable has been added.
