### PR TITLE
🚀 Optimize the display of data.

### DIFF
--- a/src/controls/outputdatawidget.cpp
+++ b/src/controls/outputdatawidget.cpp
@@ -85,8 +85,7 @@ int OutputDataListModel::rowCount(const QModelIndex&) const
 ///
 QVariant OutputDataListModel::data(const QModelIndex& index, int role) const
 {
-    if(!index.isValid() ||
-       !_mapItems.contains(index.row()))
+    if (!index.isValid())
     {
         return QVariant();
     }
@@ -96,59 +95,63 @@ QVariant OutputDataListModel::data(const QModelIndex& index, int role) const
     const auto addrSpace = _parentWidget->_displayDefinition.AddrSpace;
     const auto hexAddresses = _parentWidget->displayHexAddresses();
 
-    const ItemData& itemData = _mapItems[row];
-    const auto addrStr = formatAddress(pointType, itemData.Address, addrSpace, hexAddresses);
+    const auto itemData = _mapItems.find(row);
+    if (itemData == _mapItems.end())
+    {
+        return QVariant();
+    }
 
     switch(role)
     {
         case Qt::DisplayRole:
         {
             QString descr;
-            if (!itemData.Description.isEmpty())
+            if (!itemData->Description.isEmpty())
             {
                 const auto freeSpace = _columnsDistance - 2;
                 if (freeSpace > 0)
                 {
                     descr = QStringLiteral("; ");
-                    if (itemData.Description.length() > freeSpace)
+                    if (itemData->Description.length() > freeSpace)
                     {
                         if (freeSpace > 3)
                         {
-                            descr += itemData.Description.left(freeSpace - 3);
+                            descr += itemData->Description.left(freeSpace - 3);
                             descr += QStringLiteral("...");
                         }
                     }
                     else
                     {
-                        descr += itemData.Description;
+                        descr += itemData->Description;
                     }
                 }
             }
             const auto pad = _columnsDistance - descr.length();
-            return addrStr + QStringLiteral(": ") + itemData.ValueStr + descr + QStringLiteral(" ").repeated(pad);
+            return formatAddress(pointType, itemData->Address, addrSpace, hexAddresses) +
+                QStringLiteral(": ") + itemData->ValueStr + descr + QStringLiteral(" ").repeated(pad);
         }
 
         case CaptureRole:
-            return QString(itemData.ValueStr).remove('<').remove('>');
+            return QString(itemData->ValueStr).remove('<').remove('>');
 
         case AddressStringRole:
-            return addrStr;
+            return formatAddress(pointType, itemData->Address, addrSpace, hexAddresses);
 
         case AddressRole:
-            return itemData.Address;
+            return itemData->Address;
 
         case ValueRole:
-            return itemData.Value;
+            return itemData->Value;
 
         case ColorRole:
-            return itemData.BgColor;
+            return itemData->BgColor;
 
         case DescriptionRole:
-            return itemData.Description;
+            return itemData->Description;
 
         case Qt::DecorationRole:
         {
-            if(itemData.ValueStr.isEmpty())
+            if(itemData->ValueStr.isEmpty())
                 return _iconSimulationOff;
 
             switch(simulationIcon(row))
@@ -178,8 +181,12 @@ QVariant OutputDataListModel::data(const QModelIndex& index, int role) const
 ///
 bool OutputDataListModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-    if(!index.isValid() ||
-       !_mapItems.contains(index.row()))
+    if (!index.isValid())
+    {
+        return false;
+    }
+    const auto itemData = _mapItems.find(index.row());
+    if (itemData == _mapItems.end())
     {
         return false;
     }
@@ -187,22 +194,22 @@ bool OutputDataListModel::setData(const QModelIndex &index, const QVariant &valu
     switch (role)
     {
         case SimulationRole:
-            _mapItems[index.row()].Simulated = value.toBool();
+            itemData->Simulated = value.toBool();
             emit dataChanged(index, index, QVector<int>() << role);
         return true;
 
         case Qt::DecorationRole:
-            _mapItems[index.row()].SimulationIcon = value.value<SimulationIconType>();
+            itemData->SimulationIcon = value.value<SimulationIconType>();
             emit dataChanged(index, index, QVector<int>() << role);
         return true;
 
         case DescriptionRole:
-            _mapItems[index.row()].Description = value.toString();
+            itemData->Description = value.toString();
             emit dataChanged(index, index, QVector<int>() << role);
         return true;
 
         case ColorRole:
-            _mapItems[index.row()].BgColor = value.value<QColor>();
+            itemData->BgColor = value.value<QColor>();
             emit dataChanged(index, index, QVector<int>() << Qt::DisplayRole);
         return true;
 
@@ -252,20 +259,53 @@ void OutputDataListModel::update()
 ///
 void OutputDataListModel::updateData(const QModbusDataUnit& data)
 {
-    _lastData = data;
-
     const auto mode = _parentWidget->dataDisplayMode();
     const auto leadingZeros = _parentWidget->_displayDefinition.LeadingZeros;
     const auto pointType = _parentWidget->_displayDefinition.PointType;
     const auto byteOrder = *_parentWidget->byteOrder();
     const auto codepage = _parentWidget->codepage();
 
+    const bool all_changed =
+        !_lastData.isValid()
+        || (_lastMode != mode)
+        || (_lastLeadingZeros != leadingZeros)
+        || (_lastPointType != pointType)
+        || (_lastByteOrder != byteOrder)
+        || (_lastCodepage != codepage);
+
+    int first_changed = -1, last_changed = -1;
+
     for(int i = 0; i < rowCount(); i++)
     {
-        const auto value = _lastData.value(i);
+        const auto value = data.value(i);
 
         auto& itemData = _mapItems[i];
         itemData.Address = _parentWidget->_displayDefinition.PointAddress + i;
+
+        // Detect the changed data
+        if (!all_changed && !itemData.ValueStr.isEmpty())
+        {
+            bool skip = true;
+            for (int reg = 0; reg < registersCount(mode); ++reg)
+            {
+                if (data.value(i + reg) != _lastData.value(i + reg))
+                {
+                    skip = false;
+                    break;
+                }
+            }
+            if (skip)
+            {
+                continue;
+            }
+        }
+
+        // Adjust the range of changed data
+        if (first_changed == -1)
+        {
+            first_changed = i;
+        }
+        last_changed = i;
 
         switch(mode)
         {
@@ -291,79 +331,93 @@ void OutputDataListModel::updateData(const QModbusDataUnit& data)
 
             case DataDisplayMode::FloatingPt:
                 // MSRF
-                itemData.ValueStr = formatFloatValue(pointType, _lastData.value(i+1), value, byteOrder,
+                itemData.ValueStr = formatFloatValue(pointType, data.value(i+1), value, byteOrder,
                                                      (i%2) || (i+1>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::SwappedFP:
                 // LSRF
-                itemData.ValueStr = formatFloatValue(pointType, value, _lastData.value(i+1), byteOrder,
+                itemData.ValueStr = formatFloatValue(pointType, value, data.value(i+1), byteOrder,
                                                      (i%2) || (i+1>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::DblFloat:
                 // MSRF
-                itemData.ValueStr = formatDoubleValue(pointType, _lastData.value(i+3), _lastData.value(i+2), _lastData.value(i+1), value,
+                itemData.ValueStr = formatDoubleValue(pointType, data.value(i+3), data.value(i+2), data.value(i+1), value,
                                                       byteOrder, (i%4) || (i+3>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::SwappedDbl:
                 // LSRF
-                itemData.ValueStr = formatDoubleValue(pointType, value, _lastData.value(i+1), _lastData.value(i+2), _lastData.value(i+3),
+                itemData.ValueStr = formatDoubleValue(pointType, value, data.value(i+1), data.value(i+2), data.value(i+3),
                                                       byteOrder, (i%4) || (i+3>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::Int32:
                 // MSRF
-                itemData.ValueStr = formatInt32Value(pointType, _lastData.value(i+1), value, byteOrder,
+                itemData.ValueStr = formatInt32Value(pointType, data.value(i+1), value, byteOrder,
                                                      (i%2) || (i+1>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::SwappedInt32:
                 // LSRF
-                itemData.ValueStr = formatInt32Value(pointType, value, _lastData.value(i+1), byteOrder,
+                itemData.ValueStr = formatInt32Value(pointType, value, data.value(i+1), byteOrder,
                                                      (i%2) || (i+1>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::UInt32:
                 // MSRF
-                itemData.ValueStr = formatUInt32Value(pointType, _lastData.value(i+1), value, byteOrder, leadingZeros,
+                itemData.ValueStr = formatUInt32Value(pointType, data.value(i+1), value, byteOrder, leadingZeros,
                                                       (i%2) || (i+1>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::SwappedUInt32:
                 // LSRF
-                itemData.ValueStr = formatUInt32Value(pointType, value, _lastData.value(i+1), byteOrder, leadingZeros,
+                itemData.ValueStr = formatUInt32Value(pointType, value, data.value(i+1), byteOrder, leadingZeros,
                                                       (i%2) || (i+1>=rowCount()), itemData.Value);
                 break;
 
             case DataDisplayMode::Int64:
                 // MSRF
-                itemData.ValueStr = formatInt64Value(pointType, _lastData.value(i+3), _lastData.value(i+2), _lastData.value(i+1), value,
+                itemData.ValueStr = formatInt64Value(pointType, data.value(i+3), data.value(i+2), data.value(i+1), value,
                                                      byteOrder, (i%4) || (i+3>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::SwappedInt64:
                 // LSRF
-                itemData.ValueStr = formatInt64Value(pointType, value, _lastData.value(i+1), _lastData.value(i+2), _lastData.value(i+3),
+                itemData.ValueStr = formatInt64Value(pointType, value, data.value(i+1), data.value(i+2), data.value(i+3),
                                                      byteOrder, (i%4) || (i+3>=rowCount()), itemData.Value);
                 break;
 
             case DataDisplayMode::UInt64:
                 // MSRF
-                itemData.ValueStr = formatUInt64Value(pointType, _lastData.value(i+3), _lastData.value(i+2), _lastData.value(i+1), value,
+                itemData.ValueStr = formatUInt64Value(pointType, data.value(i+3), data.value(i+2), data.value(i+1), value,
                                                       byteOrder, leadingZeros, (i%4) || (i+3>=rowCount()), itemData.Value);
             break;
 
             case DataDisplayMode::SwappedUInt64:
                 // LSRF
-                itemData.ValueStr = formatUInt64Value(pointType, value, _lastData.value(i+1), _lastData.value(i+2), _lastData.value(i+3),
+                itemData.ValueStr = formatUInt64Value(pointType, value, data.value(i+1), data.value(i+2), data.value(i+3),
                                                       byteOrder, leadingZeros, (i%4) || (i+3>=rowCount()), itemData.Value);
             break;
         }
     }
 
-    emit dataChanged(index(0), index(rowCount() - 1), QVector<int>() << Qt::DisplayRole);
+    if (all_changed || first_changed != -1)
+    {
+        _lastData = data;
+        _lastMode = mode;
+        _lastLeadingZeros = leadingZeros;
+        _lastPointType = pointType;
+        _lastByteOrder = byteOrder;
+        _lastCodepage = codepage;
+
+        // Notify changed data only
+        if (first_changed != -1)
+        {
+            emit dataChanged(index(first_changed), index(last_changed), QVector<int>() << Qt::DisplayRole);
+        }
+    }
 }
 
 ///
@@ -399,8 +453,12 @@ OutputDataListModel::SimulationIconType OutputDataListModel::simulationIcon(int 
         if(row + i >= rowCount())
             return SimulationIconNone;
 
-        if(_mapItems[row + i].Simulated)
-            return _mapItems[row + i].SimulationIcon;
+        const auto itemData = _mapItems.find(row + i);
+        if (itemData == _mapItems.end())
+            return SimulationIconNone;
+
+        if(itemData->Simulated)
+            return itemData->SimulationIcon;
     }
 
     return SimulationIconNone;
@@ -420,6 +478,7 @@ OutputDataWidget::OutputDataWidget(QWidget *parent) :
 {
     ui->setupUi(this);
     ui->stackedWidget->setCurrentIndex(0);
+    ui->listView->setUniformItemSizes(true);
     ui->listView->setModel(_listModel.get());
     ui->listView->setItemDelegate(new DataDelegate( this ));
     ui->labelStatus->setAutoFillBackground(true);

--- a/src/controls/outputdatawidget.h
+++ b/src/controls/outputdatawidget.h
@@ -79,6 +79,11 @@ private:
 
     OutputDataWidget* _parentWidget;
     QModbusDataUnit _lastData;
+    DataDisplayMode _lastMode = DataDisplayMode::Binary;
+    bool _lastLeadingZeros = false;
+    QModbusDataUnit::RegisterType _lastPointType = QModbusDataUnit::RegisterType::Invalid;
+    ByteOrder _lastByteOrder = ByteOrder::Direct;
+    QString _lastCodepage;
     const QPixmap _iconSimulation16Bit;
     const QPixmap _iconSimulation32Bit;
     const QPixmap _iconSimulation64Bit;

--- a/src/formatutils.h
+++ b/src/formatutils.h
@@ -489,30 +489,37 @@ inline QString formatUInt64Value(QModbusDataUnit::RegisterType pointType, quint1
 /// \param hexFormat
 /// \return
 ///
-inline QString formatAddress(QModbusDataUnit::RegisterType pointType, int address, AddressSpace space, bool hexFormat)
+inline QString formatAddress(QModbusDataUnit::RegisterType pointType, quint16 address, AddressSpace space, bool hexFormat)
 {
-    QString prefix;
-    switch(pointType)
+    char str[8];
+    if(hexFormat)
     {
-        case QModbusDataUnit::Coils:
-            prefix = "0";
-            break;
-        case QModbusDataUnit::DiscreteInputs:
-            prefix = "1";
-            break;
-        case QModbusDataUnit::HoldingRegisters:
-            prefix = "4";
-            break;
-        case QModbusDataUnit::InputRegisters:
-            prefix = "3";
-            break;
-        default:
-            break;
+        snprintf(str, sizeof(str), "0x%04X", address);
     }
-
-    const int width = space == AddressSpace::Addr6Digits ? 5 : 4;
-    return hexFormat ? QString("0x%1").arg(QString::number(address, 16).toUpper(), 4, '0') :
-               prefix + QStringLiteral("%1").arg(address, width, 10, QLatin1Char('0'));
+    else
+    {
+	    switch(pointType)
+	    {
+	        case QModbusDataUnit::Coils:
+	            *str = '0';
+	            break;
+	        case QModbusDataUnit::DiscreteInputs:
+	            *str = '1';
+	            break;
+	        case QModbusDataUnit::HoldingRegisters:
+	            *str = '4';
+	            break;
+	        case QModbusDataUnit::InputRegisters:
+	            *str = '3';
+	            break;
+	        default:
+	            *str = ' ';
+	            break;
+	    }
+        const int width = space == AddressSpace::Addr6Digits ? 5 : 4;
+        snprintf(str + 1, sizeof(str) - 1, "%0*u", width, address);
+    }
+    return str;
 }
 
 #endif // FORMATUTILS_H

--- a/src/modbusmultiserver.cpp
+++ b/src/modbusmultiserver.cpp
@@ -1,4 +1,4 @@
-﻿#include <algorithm>
+#include <algorithm>
 #include "numericutils.h"
 #include "modbustcpserver.h"
 #include "modbusrtuserialserver.h"
@@ -528,7 +528,10 @@ QModbusDevice::State ModbusMultiServer::state(ConnectionType type, const QString
 ///
 QModbusDataUnit ModbusMultiServer::data(quint8 deviceId, QModbusDataUnit::RegisterType pointType, quint16 pointAddress, quint16 length) const
 {
-    return _modbusDataUnitMaps[deviceId].getData(pointType, pointAddress, length);
+    const auto item = _modbusDataUnitMaps.find(deviceId);
+    return (item != _modbusDataUnitMaps.end())
+        ? item->getData(pointType, pointAddress, length)
+        : QModbusDataUnit();
 }
 
 ///


### PR DESCRIPTION
- `OutputDataListModel::data()`:
    - Removed copying of the `OutputDataListModel::ItemData` structure each time a register address is printed.
    - Removed unnecessary printing of the address, even when the address is not used.
    - Set a flag for uniform size for all list items using `setUniformItemSizes(true)`; the size is effectively the same.
	- Speedup: 2000ms -> 615ms.
- `OutputDataListModel::simulationIcon()`:
    - Removed copying of the `OutputDataListModel::ItemData` structure each time a register simulation icon is printed.
    - Speedup: 320ms -> 23ms (included in `OutputDataListModel::data`).
- `formatAddress()`:
    - Optimized address printing.
    - Speedup: 587 ms > 90 ms (included in `OutputDataListModel::data`).
- `OutputDataListModel::updateData()`:
    - Checks and updates only changed data.
    - Speedup: 295 ms > 58 ms.
- `ModbusMultiServer::data()`:
    - Removed copying of the `ModbusDataUnitMap` structure.
    - Speedup: 55 ms > 27 ms.

Benchmark note: 30-second run, debug version, 100 registers + auto-simulation of 2 registers with a 100 ms period; ~27,000 calls to `DataDelegate::paint()` were made while printing the registers.

This PR will also help with issue #89.

