### PR TITLE
Resolve GCC 8.1 compatibility issue.

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -7,11 +7,7 @@
 
 template<typename Enum>
 struct EnumStrings {
-    static const QMap<Enum, QString>& mapping() {
-        static_assert(false, "Use DECLARE_ENUM_STRINGS() macro to define: " __FUNCTION__);
-        static const QMap<Enum, QString> map;
-        return map;
-    }
+    static const QMap<Enum, QString>& mapping() = delete; // Use DECLARE_ENUM_STRINGS() macro
 };
 
 #define DECLARE_ENUM_STRINGS(EnumType, ...) \


### PR DESCRIPTION
Using old GCC 8.1, which is included in the last version of Qt 5.15, results in a compilation error for the `EnumStrings` template in the `enums.h` file. Although this compiler supports C++17, it performs explicit template instantiation even if the template is not used, causing a false positive in the `static_assert`.

The proposal is to replace the assert with a deleted function. This will also result in a compilation error if the function is used without defining the `DECLARE_ENUM_STRINGS` macro, which is the intended behavior.