### PR TITLE
Fix project file version 1.x compatibility.

### DIFF
--- a/src/appproject.cpp
+++ b/src/appproject.cpp
@@ -1792,6 +1792,10 @@ void AppProject::loadProject(const QString& filename)
                         bool isForm = true;
                         if (xml.name() == QLatin1String("FormDataView")) {
                             kind = ProjectFormKind::Data;
+                        // Version 1.x multi-view project
+                        } else if (xml.name() == QLatin1String("FormModSim")) {
+                            kind = ProjectFormKind::Data;
+                            _mainWindow->setViewMode(viewMode = QMdiArea::SubWindowView);
                         } else if (xml.name() == QLatin1String("FormTrafficView")) {
                             kind = ProjectFormKind::Traffic;
                         } else if (xml.name() == QLatin1String("FormScriptView")) {
@@ -1941,6 +1945,14 @@ void AppProject::loadProject(const QString& filename)
                 else {
                     xml.skipCurrentElement();
                 }
+            }
+        }
+        // Version 1.x single view project
+        else if (xml.name() == QLatin1String("FormModSim")) {
+            _mainWindow->setViewMode(viewMode = QMdiArea::SubWindowView);
+            if (const auto frm = createMdiChild(ProjectFormKind::Data)) {
+                loadXmlOfForm(frm, xml);
+                frm->show();
             }
         }
         else {

--- a/src/controls/outputtypes.h
+++ b/src/controls/outputtypes.h
@@ -229,17 +229,17 @@ inline QXmlStreamReader& operator>>(QXmlStreamReader& in, AddressColorMap& map)
         if (in.name() == QLatin1String("Color")) {
             const auto attributes = in.attributes();
             bool ok;
-            const auto device_id = static_cast<quint8>(attributes.value("DeviceId").toUShort(&ok));
+            auto device_id = static_cast<quint8>(attributes.value("DeviceId").toUShort(&ok));
+            if (!ok)
+                device_id = 0; // use current view device id
+            auto type = static_cast<QModbusDataUnit::RegisterType>(attributes.value("Type").toInt(&ok));
+            if (!ok)
+                type = QModbusDataUnit::RegisterType::Invalid; // use current view type
+            const auto address = attributes.value("Address").toUShort(&ok);
             if (ok) {
-                const auto type = static_cast<QModbusDataUnit::RegisterType>(attributes.value("Type").toInt(&ok));
-                if (ok) {
-                    const auto address = attributes.value("Address").toUShort(&ok);
-                    if (ok) {
-                        const auto value = attributes.value("Value").toString();
-                        if (!value.isEmpty())
-                            map.insert({ device_id, type, address }, value);
-                    }
-                }
+                const auto value = attributes.value("Value").toString();
+                if (!value.isEmpty())
+                    map.insert({ device_id, type, address }, value);
             }
         }
         in.skipCurrentElement();

--- a/src/displaydefinition.h
+++ b/src/displaydefinition.h
@@ -290,7 +290,9 @@ inline QXmlStreamWriter& operator <<(QXmlStreamWriter& xml, const ScriptViewDefi
 ///
 inline QXmlStreamReader& operator >>(QXmlStreamReader& xml, DataViewDefinitions& dd)
 {
-    if (xml.isStartElement() && xml.name() == QLatin1String("DataViewDefinitions")) {
+    if (xml.isStartElement() && (xml.name() == QLatin1String("DataViewDefinitions") ||
+        // Version 1.x definitions
+        xml.name() == QLatin1String("DisplayDefinition"))) {
         const QXmlStreamAttributes attributes = xml.attributes();
 
         if (attributes.hasAttribute("FormName")) {

--- a/src/formdataview.cpp
+++ b/src/formdataview.cpp
@@ -163,6 +163,15 @@ FormDataView::~FormDataView()
 }
 
 ///
+/// \brief FormDataView::project
+/// \return
+///
+AppProject* FormDataView::project() const noexcept
+{
+    return _parent->project();
+}
+
+///
 /// \brief FormDataView::saveSettings
 /// \param out
 ///
@@ -1326,4 +1335,332 @@ void FormDataView::updateDisplayBar()
     if (_ansiMenu) _ansiMenu->selectCodepage(codepage());
 
     updateSettingsControls();
+}
+
+///
+/// \brief operator <<
+/// \param xml
+/// \param frm
+/// \return
+///
+inline QXmlStreamWriter& operator <<(QXmlStreamWriter& xml, FormDataView* frm)
+{
+    if (!frm) return xml;
+
+    xml.writeStartElement("FormDataView");
+
+    const auto panel = frm->property("SplitPanel").toString();
+    if(!panel.isEmpty())
+        xml.writeAttribute("Panel", panel);
+    xml.writeAttribute("Title", frm->windowTitle());
+    if(frm->property("SplitAutoClone").toBool())
+        xml.writeAttribute("AutoClone", "1");
+    if(frm->property("Closed").toBool())
+        xml.writeAttribute("Closed", "1");
+    xml.writeAttribute("DataType", enumToString<DataType>(frm->dataType()));
+    xml.writeAttribute("RegisterOrder", enumToString<RegisterOrder>(frm->registerOrder()));
+    xml.writeAttribute("Codepage", frm->codepage());
+    xml.writeAttribute("ByteOrder", enumToString<ByteOrder>(frm->byteOrder()));
+
+    const auto wnd = frm->parentWidget();
+    xml.writeStartElement("Window");
+    xml.writeAttribute("Maximized", boolToString(wnd->isMaximized()));
+    xml.writeAttribute("Minimized", boolToString(wnd->isMinimized()));
+
+    const auto windowPos = wnd->pos();
+    xml.writeAttribute("Left", QString::number(windowPos.x()));
+    xml.writeAttribute("Top", QString::number(windowPos.y()));
+
+    const auto windowSize = (wnd->isMinimized() || wnd->isMaximized()) ? wnd->sizeHint() : wnd->size();
+    xml.writeAttribute("Width", QString::number(windowSize.width()));
+    xml.writeAttribute("Height", QString::number(windowSize.height()));
+    xml.writeEndElement();
+
+    const auto dd = frm->displayDefinition();
+    xml.writeStartElement("DataViewDefinitions");
+    xml.writeAttribute("DeviceId", QString::number(dd.DeviceId));
+    xml.writeAttribute("PointType", enumToString<QModbusDataUnit::RegisterType>(dd.PointType));
+    xml.writeAttribute("PointAddress", QString::number(dd.PointAddress));
+    xml.writeAttribute("Length", QString::number(dd.Length));
+    xml.writeAttribute("DataViewColumnsDistance", QString::number(dd.DataViewColumnsDistance));
+    xml.writeAttribute("LeadingZeros", boolToString(dd.LeadingZeros));
+    xml.writeEndElement();
+
+    xml << frm->colorMap();
+
+    xml.writeEndElement(); // FormDataView
+
+    return xml;
+}
+
+///
+/// \brief operator >>
+/// \param xml
+/// \param frm
+/// \return
+///
+QXmlStreamReader& operator >>(QXmlStreamReader& xml, FormDataView* frm)
+{
+    if (!frm) return xml;
+
+    if (xml.isStartElement() && (xml.name() == QLatin1String("FormDataView") ||
+        // Version 1.x data view
+        xml.name() == QLatin1String("FormModSim"))) {
+        DataType dataType = DataType::UInt16;
+        RegisterOrder regOrder = RegisterOrder::MSRF;
+        DataViewDefinitions dd;
+        QHash<quint16, quint16> data;
+        QHash<quint16, ModbusSimulationParams> simulations;
+
+        // Version 1.x script view
+        FormScriptView * script = nullptr;
+        ScriptViewDefinitions script_dd;
+
+        const QXmlStreamAttributes attributes = xml.attributes();
+        const QString formTitle = attributes.value("Title").toString();
+
+        if (attributes.hasAttribute("DataType")) {
+            dataType = enumFromString<DataType>(attributes.value("DataType").toString(), DataType::UInt16);
+        }
+
+        // Version 1.x data type
+        if (attributes.hasAttribute("DataDisplayMode")) {
+            dataType = enumFromString<DataType>(attributes.value("DataDisplayMode").toString(), DataType::UInt16);
+        }
+
+        if (attributes.hasAttribute("RegisterOrder")) {
+            regOrder = enumFromString<RegisterOrder>(attributes.value("RegisterOrder").toString(), RegisterOrder::MSRF);
+        }
+
+        if (attributes.hasAttribute("Codepage")) {
+            frm->setCodepage(attributes.value("Codepage").toString());
+        }
+
+        if (attributes.hasAttribute("ByteOrder")) {
+            const ByteOrder order = enumFromString<ByteOrder>(attributes.value("ByteOrder").toString());
+            frm->setByteOrder(order);
+        }
+
+        while (xml.readNextStartElement()) {
+            if (xml.name() == QLatin1String("Window")) {
+                const QXmlStreamAttributes windowAttrs = xml.attributes();
+
+                const auto wnd = frm->parentWidget();
+                if (wnd) {
+                    if(windowAttrs.hasAttribute("Left") && windowAttrs.hasAttribute("Top")) {
+                        bool okLeft, okTop;
+                        const int left = windowAttrs.value("Left").toInt(&okLeft);
+                        const int top = windowAttrs.value("Top").toInt(&okTop);
+                        if(okLeft && okTop) {
+                            wnd->move(left, top);
+                        }
+                    }
+
+                    if (windowAttrs.hasAttribute("Width") && windowAttrs.hasAttribute("Height")) {
+                        bool okWidth, okHeight;
+                        const int width = windowAttrs.value("Width").toInt(&okWidth);
+                        const int height = windowAttrs.value("Height").toInt(&okHeight);
+
+                        if (okWidth && okHeight && !wnd->isMaximized() && !wnd->isMinimized()) {
+                            wnd->resize(width, height);
+                        }
+                    }
+
+                    if (windowAttrs.hasAttribute("Maximized")) {
+                        const bool maximized = stringToBool(windowAttrs.value("Maximized").toString());
+                        if (maximized) wnd->showMaximized();
+                    }
+
+                    if (windowAttrs.hasAttribute("Minimized")) {
+                        const bool minimized = stringToBool(windowAttrs.value("Minimized").toString());
+                        if (minimized) wnd->showMinimized();
+                    }
+
+
+                }
+                xml.skipCurrentElement();
+            }
+            else if (xml.name() == QLatin1String("DataViewDefinitions")) {
+                xml >> dd;
+                xml.skipCurrentElement();
+                if (dd.FormName.isEmpty() && !formTitle.isEmpty())
+                    dd.FormName = formTitle;
+                frm->setDisplayDefinition(dd);
+            }
+            // Version 1.x definitions
+            else if (xml.name() == QLatin1String("DisplayDefinition")) {
+                const auto attributes = xml.attributes();
+                xml >> dd;
+                xml.skipCurrentElement();
+
+                // Reload PointAddress since it may be wrongly normalized from 0 to 1
+                if (attributes.hasAttribute("PointAddress")) {
+                    dd.PointAddress = attributes.value("PointAddress").toUShort();
+                }
+                if (attributes.hasAttribute("ZeroBasedAddress")) {
+                    if (stringToBool(attributes.value("ZeroBasedAddress").toString())) {
+                        frm->setAddressBase(AddressBase::Base0);
+                    } else {
+                        frm->setAddressBase(AddressBase::Base1);
+                    }
+                }
+
+                frm->setDisplayDefinition(dd);
+            }
+            // Version 1.x simulation map
+            else if (xml.name() == QLatin1String("ModbusSimulationMap")) {
+                while (xml.readNextStartElement()) {
+                    if (xml.name() == QLatin1String("Simulation")) {
+
+                        const QXmlStreamAttributes attributes = xml.attributes();
+                        bool ok; const quint16 address = attributes.value("Address").toUShort(&ok);
+
+                        if(ok) {
+                            xml.readNextStartElement();
+
+                            ModbusSimulationParams params;
+                            xml >> params;
+
+                            simulations[address] = params;
+                        }
+
+                        xml.skipCurrentElement();
+
+                    } else {
+                        xml.skipCurrentElement();
+                    }
+                }
+            }
+            // Version 1.x script control
+            else if (xml.name() == QLatin1String("JScriptControl")) {
+                if (script = static_cast<FormScriptView*>(frm->project()->createMdiChild(ProjectFormKind::Script))) {
+                    xml >> script->scriptControl();
+                } else {
+                    xml.skipCurrentElement();
+                }
+            }
+            // Version 1.x script settings
+            else if (xml.name() == QLatin1String("ScriptSettings")) {
+                xml >> script_dd.ScriptCfg;
+            }
+            else if (xml.name() == QLatin1String("AddressDescriptionMap")) {
+                AddressDescriptionMap map;
+                xml >> map;
+                for(auto it = map.cbegin(); it != map.cend(); ++it)
+                {
+                    const auto device_id = it.key().DeviceId;
+                    const auto type = it.key().Type;
+                    frm->setDescription(device_id ? device_id : dd.DeviceId, type ? type : dd.PointType, it.key().Address, it.value());
+                }
+            }
+            else if (xml.name() == QLatin1String("AddressColorMap")) {
+                AddressColorMap map;
+                xml >> map;
+                for(auto it = map.cbegin(); it != map.cend(); ++it)
+                {
+                    const auto device_id = it.key().DeviceId;
+                    const auto type = it.key().Type;
+                    frm->setColor(device_id ? device_id : dd.DeviceId, type ? type : dd.PointType, it.key().Address, it.value());
+                }
+            }
+            // Version 1.x data units
+            else if (xml.name() == QLatin1String("ModbusDataUnit")) {
+                while (xml.readNextStartElement()) {
+                    if (xml.name() == QLatin1String("Value")) {
+                        QXmlStreamAttributes attributes = xml.attributes();
+                        bool ok; const quint16 address = attributes.value("Address").toUShort(&ok);
+                        if(ok) {
+                            const quint16 value = xml.readElementText().toUShort(&ok);
+                            if (ok) {
+                                data[address] = value;
+                            }
+                        }
+                    } else {
+                        xml.skipCurrentElement();
+                    }
+                }
+            }
+            else {
+                xml.skipCurrentElement();
+            }
+        }
+
+        if(dd.PointType != QModbusDataUnit::Invalid) {
+            frm->setDataType(dataType);
+            frm->setRegisterOrder(regOrder);
+
+            // Version 1.x simulation map
+            if(!simulations.isEmpty()) {
+                QHashIterator it(simulations);
+                while(it.hasNext()) {
+                    const auto item = it.next();
+					const auto index = item.key() - (frm->zeroBasedAddress() ? 0 : 1);
+ 					if (index < 0) {
+						// Malformed file
+						break;
+					}
+                    switch(dd.PointType) {
+                        case QModbusDataUnit::Coils:
+                        case QModbusDataUnit::DiscreteInputs:
+                            if(item->Mode == SimulationMode::Toggle || item->Mode == SimulationMode::Random)
+                                frm->startSimulation(dd.PointType, index, item.value());
+                            break;
+                        case QModbusDataUnit::InputRegisters:
+                        case QModbusDataUnit::HoldingRegisters:
+                            if(item->Mode != SimulationMode::Off && item->Mode != SimulationMode::Toggle)
+                                frm->startSimulation(dd.PointType, index, item.value());
+                            break;
+                        default: break;
+                    }
+                }
+            }
+
+            // Version 1.x data units
+            if (!data.isEmpty()) {
+                QVector<quint16> values(dd.Length);
+
+                QHashIterator it(data);
+                while(it.hasNext()) {
+                    const auto item = it.next();
+                    const auto index = item.key() - dd.PointAddress;
+					if (index < 0 || index >= dd.Length) {
+						// Malformed file
+						break;
+					}
+                    switch(dd.PointType) {
+                        case QModbusDataUnit::Coils:
+                        case QModbusDataUnit::DiscreteInputs:
+                            values[index] = qBound<quint16>(0, item.value(), 1);
+                            break;
+                        case QModbusDataUnit::InputRegisters:
+                        case QModbusDataUnit::HoldingRegisters:
+                            values[index] = item.value();
+                            break;
+                        default: break;
+                    }
+                }
+
+                frm->configureModbusDataUnit(dd.DeviceId, dd.PointType, qMax(dd.PointAddress - (frm->zeroBasedAddress() ? 0 : 1), 0), values);
+            }
+        }
+
+        // Version 1.x script
+        if (script) {
+            script_dd.FormName = frm->windowTitle(); // the same title as data view
+            script_dd.normalize();
+            script->setDefinitions(script_dd);
+            script->setFont(AppPreferences::instance().scriptFont());
+
+            frm->project()->closeMdiChild(script); // script view hidden by default
+
+            if (script_dd.ScriptCfg.RunOnStartup) {
+                script->runScript();
+            }
+        }
+    }
+    else {
+        xml.skipCurrentElement();
+    }
+
+    return xml;
 }

--- a/src/formdataview.h
+++ b/src/formdataview.h
@@ -27,6 +27,7 @@
 ///
 class MainWindow;
 class FindReplaceBar;
+class AppProject;
 
 namespace Ui {
 class FormDataView;
@@ -48,6 +49,8 @@ class FormDataView : public QWidget
 public:
     explicit FormDataView(ModbusMultiServer& server, DataSimulator* simulator, MainWindow* parent);
     ~FormDataView();
+
+    AppProject* project() const noexcept;
 
     QVector<quint16> data() const;
 
@@ -267,55 +270,7 @@ inline QSettings& operator >>(QSettings& in, FormDataView* frm)
 /// \param frm
 /// \return
 ///
-inline QXmlStreamWriter& operator <<(QXmlStreamWriter& xml, FormDataView* frm)
-{
-    if (!frm) return xml;
-
-    xml.writeStartElement("FormDataView");
-
-    const auto panel = frm->property("SplitPanel").toString();
-    if(!panel.isEmpty())
-        xml.writeAttribute("Panel", panel);
-    xml.writeAttribute("Title", frm->windowTitle());
-    if(frm->property("SplitAutoClone").toBool())
-        xml.writeAttribute("AutoClone", "1");
-    if(frm->property("Closed").toBool())
-        xml.writeAttribute("Closed", "1");
-    xml.writeAttribute("DataType", enumToString<DataType>(frm->dataType()));
-    xml.writeAttribute("RegisterOrder", enumToString<RegisterOrder>(frm->registerOrder()));
-    xml.writeAttribute("Codepage", frm->codepage());
-    xml.writeAttribute("ByteOrder", enumToString<ByteOrder>(frm->byteOrder()));
-
-    const auto wnd = frm->parentWidget();
-    xml.writeStartElement("Window");
-    xml.writeAttribute("Maximized", boolToString(wnd->isMaximized()));
-    xml.writeAttribute("Minimized", boolToString(wnd->isMinimized()));
-
-    const auto windowPos = wnd->pos();
-    xml.writeAttribute("Left", QString::number(windowPos.x()));
-    xml.writeAttribute("Top", QString::number(windowPos.y()));
-
-    const auto windowSize = (wnd->isMinimized() || wnd->isMaximized()) ? wnd->sizeHint() : wnd->size();
-    xml.writeAttribute("Width", QString::number(windowSize.width()));
-    xml.writeAttribute("Height", QString::number(windowSize.height()));
-    xml.writeEndElement();
-
-    const auto dd = frm->displayDefinition();
-    xml.writeStartElement("DataViewDefinitions");
-    xml.writeAttribute("DeviceId", QString::number(dd.DeviceId));
-    xml.writeAttribute("PointType", enumToString<QModbusDataUnit::RegisterType>(dd.PointType));
-    xml.writeAttribute("PointAddress", QString::number(dd.PointAddress));
-    xml.writeAttribute("Length", QString::number(dd.Length));
-    xml.writeAttribute("DataViewColumnsDistance", QString::number(dd.DataViewColumnsDistance));
-    xml.writeAttribute("LeadingZeros", boolToString(dd.LeadingZeros));
-    xml.writeEndElement();
-
-    xml << frm->colorMap();
-
-    xml.writeEndElement(); // FormDataView
-
-    return xml;
-}
+QXmlStreamWriter& operator <<(QXmlStreamWriter& xml, FormDataView* frm);
 
 ///
 /// \brief operator >>
@@ -323,205 +278,7 @@ inline QXmlStreamWriter& operator <<(QXmlStreamWriter& xml, FormDataView* frm)
 /// \param frm
 /// \return
 ///
-inline QXmlStreamReader& operator >>(QXmlStreamReader& xml, FormDataView* frm)
-{
-    if (!frm) return xml;
-
-    if (xml.isStartElement() && xml.name() == QLatin1String("FormDataView")) {
-        DataType dataType = DataType::UInt16;
-        RegisterOrder regOrder = RegisterOrder::MSRF;
-        DataViewDefinitions dd;
-        QHash<quint16, quint16> data;
-        QHash<quint16, ModbusSimulationParams> simulations;
-
-        const QXmlStreamAttributes attributes = xml.attributes();
-        const QString formTitle = attributes.value("Title").toString();
-
-        if (attributes.hasAttribute("DataType")) {
-            dataType = enumFromString<DataType>(attributes.value("DataType").toString(), DataType::UInt16);
-        }
-
-        if (attributes.hasAttribute("RegisterOrder")) {
-            regOrder = enumFromString<RegisterOrder>(attributes.value("RegisterOrder").toString(), RegisterOrder::MSRF);
-        }
-
-        if (attributes.hasAttribute("Codepage")) {
-            frm->setCodepage(attributes.value("Codepage").toString());
-        }
-
-        if (attributes.hasAttribute("ByteOrder")) {
-            const ByteOrder order = enumFromString<ByteOrder>(attributes.value("ByteOrder").toString());
-            frm->setByteOrder(order);
-        }
-
-        while (xml.readNextStartElement()) {
-            if (xml.name() == QLatin1String("Window")) {
-                const QXmlStreamAttributes windowAttrs = xml.attributes();
-
-                const auto wnd = frm->parentWidget();
-                if (wnd) {
-                    if(windowAttrs.hasAttribute("Left") && windowAttrs.hasAttribute("Top")) {
-                        bool okLeft, okTop;
-                        const int left = windowAttrs.value("Left").toInt(&okLeft);
-                        const int top = windowAttrs.value("Top").toInt(&okTop);
-                        if(okLeft && okTop) {
-                            wnd->move(left, top);
-                        }
-                    }
-
-                    if (windowAttrs.hasAttribute("Width") && windowAttrs.hasAttribute("Height")) {
-                        bool okWidth, okHeight;
-                        const int width = windowAttrs.value("Width").toInt(&okWidth);
-                        const int height = windowAttrs.value("Height").toInt(&okHeight);
-
-                        if (okWidth && okHeight && !wnd->isMaximized() && !wnd->isMinimized()) {
-                            wnd->resize(width, height);
-                        }
-                    }
-
-                    if (windowAttrs.hasAttribute("Maximized")) {
-                        const bool maximized = stringToBool(windowAttrs.value("Maximized").toString());
-                        if (maximized) wnd->showMaximized();
-                    }
-
-                    if (windowAttrs.hasAttribute("Minimized")) {
-                        const bool minimized = stringToBool(windowAttrs.value("Minimized").toString());
-                        if (minimized) wnd->showMinimized();
-                    }
-
-
-                }
-                xml.skipCurrentElement();
-            }
-            else if (xml.name() == QLatin1String("DataViewDefinitions")) {
-                xml >> dd;
-                xml.skipCurrentElement();
-                if (dd.FormName.isEmpty() && !formTitle.isEmpty())
-                    dd.FormName = formTitle;
-                frm->setDisplayDefinition(dd);
-            }
-            else if (xml.name() == QLatin1String("ModbusSimulationMap")) {
-                while (xml.readNextStartElement()) {
-                    if (xml.name() == QLatin1String("Simulation")) {
-
-                        const QXmlStreamAttributes attributes = xml.attributes();
-                        bool ok; const quint16 address = attributes.value("Address").toUShort(&ok);
-
-                        if(ok) {
-                            xml.readNextStartElement();
-
-                            ModbusSimulationParams params;
-                            xml >> params;
-
-                            simulations[address] = params;
-                        }
-
-                        xml.skipCurrentElement();
-
-                    } else {
-                        xml.skipCurrentElement();
-                    }
-                }
-            }
-            else if (xml.name() == QLatin1String("JScriptControl")) {
-                xml.skipCurrentElement();
-            }
-            else if (xml.name() == QLatin1String("AddressDescriptionMap")) {
-                AddressDescriptionMap map;
-                xml >> map;
-                for(auto it = map.cbegin(); it != map.cend(); ++it)
-                {
-                    const auto device_id = it.key().DeviceId;
-                    const auto type = it.key().Type;
-                    frm->setDescription(device_id ? device_id : dd.DeviceId, type ? type : dd.PointType, it.key().Address, it.value());
-                }
-            }
-            else if (xml.name() == QLatin1String("AddressColorMap")) {
-                AddressColorMap map;
-                xml >> map;
-                for(auto it = map.cbegin(); it != map.cend(); ++it)
-                {
-                    const auto device_id = it.key().DeviceId;
-                    const auto type = it.key().Type;
-                    frm->setColor(device_id ? device_id : dd.DeviceId, type ? type : dd.PointType, it.key().Address, it.value());
-                }
-            }
-            else if (xml.name() == QLatin1String("ModbusDataUnit")) {
-                while (xml.readNextStartElement()) {
-                    if (xml.name() == QLatin1String("Value")) {
-                        QXmlStreamAttributes attributes = xml.attributes();
-                        bool ok; const quint16 address = attributes.value("Address").toUShort(&ok);
-                        if(ok) {
-                            const quint16 value = xml.readElementText().toUShort(&ok);
-                            if (ok) {
-                                data[address] = value;
-                            }
-                        }
-                    } else {
-                        xml.skipCurrentElement();
-                    }
-                }
-            }
-            else {
-                xml.skipCurrentElement();
-            }
-        }
-
-        if(dd.PointType != QModbusDataUnit::Invalid) {
-            frm->setDataType(dataType);
-            frm->setRegisterOrder(regOrder);
-
-            if(!simulations.isEmpty()) {
-                QHashIterator it(simulations);
-                while(it.hasNext()) {
-                    const auto item = it.next();
-                    switch(dd.PointType) {
-                        case QModbusDataUnit::Coils:
-                        case QModbusDataUnit::DiscreteInputs:
-                            if(item->Mode == SimulationMode::Toggle || item->Mode == SimulationMode::Random)
-                                frm->startSimulation(dd.PointType, item.key() - (frm->zeroBasedAddress() ? 0 : 1), item.value());
-                            break;
-                        case QModbusDataUnit::InputRegisters:
-                        case QModbusDataUnit::HoldingRegisters:
-                            if(item->Mode != SimulationMode::Off && item->Mode != SimulationMode::Toggle)
-                                frm->startSimulation(dd.PointType, item.key() - (frm->zeroBasedAddress() ? 0 : 1), item.value());
-                            break;
-                        default: break;
-                    }
-                }
-            }
-
-            if (!data.isEmpty()) {
-                QVector<quint16> values(dd.Length);
-
-                QHashIterator it(data);
-                while(it.hasNext()) {
-                    const auto item = it.next();
-                    const auto index = item.key() - dd.PointAddress;
-                    switch(dd.PointType) {
-                        case QModbusDataUnit::Coils:
-                        case QModbusDataUnit::DiscreteInputs:
-                            values[index] = qBound<quint16>(0, item.value(), 1);
-                            break;
-                        case QModbusDataUnit::InputRegisters:
-                        case QModbusDataUnit::HoldingRegisters:
-                            values[index] = item.value();
-                            break;
-                        default: break;
-                    }
-                    if(index >= values.length()) break;
-                }
-
-                frm->configureModbusDataUnit(dd.DeviceId, dd.PointType, dd.PointAddress - (frm->zeroBasedAddress() ? 0 : 1), values);
-            }
-        }
-    }
-    else {
-        xml.skipCurrentElement();
-    }
-
-    return xml;
-}
+QXmlStreamReader& operator >>(QXmlStreamReader& xml, FormDataView* frm);
 
 #endif // FORMDATAVIEW_H
 

--- a/src/formscriptview.cpp
+++ b/src/formscriptview.cpp
@@ -483,7 +483,7 @@ void FormScriptView::linkRunStopTo(FormScriptView* master)
 /// \brief FormScriptView::scriptControl
 /// \return
 ///
-JScriptControl* FormScriptView::scriptControl()
+JScriptControl* FormScriptView::scriptControl() const noexcept
 {
     return ui->scriptControl;
 }

--- a/src/formscriptview.h
+++ b/src/formscriptview.h
@@ -65,6 +65,7 @@ public:
     void setScript(const QString& text);
     QTextDocument* scriptDocument() const;
     void setScriptDocument(QTextDocument* document);
+    JScriptControl* scriptControl() const noexcept;
 
     int scriptCursorPosition() const;
     void setScriptCursorPosition(int pos);
@@ -131,8 +132,6 @@ signals:
     void consoleMessage(const QString& source, const QString& text, ConsoleOutput::MessageType type);
 
 private:
-    JScriptControl* scriptControl();
-
     void setupScriptBar();
     void updateScriptBar();
     void updateScriptBarToolTips();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -929,6 +929,7 @@ void MainWindow::on_actionOpenProject_triggered()
 {
     QStringList filters;
     filters << tr("Project files (*.omsim)");
+    filters << tr("Project 1.x files (*.xml)");
     filters << tr("All files (*)");
 
     const auto filename = QFileDialog::getOpenFileName(this, QString(), _project->savePath(), filters.join(";;"));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,6 +60,7 @@ public:
 
     void loadProject(const QString& filename);
     bool saveProject(const QString& filename);
+    inline AppProject* project() const noexcept { return _project; }
 
     void appendConsoleMessage(const QString& source, const QString& text, ConsoleOutput::MessageType type);
     void showOutputConsole();
@@ -84,7 +85,7 @@ public slots:
     void windowActivate(QMdiSubWindow* wnd);
     void updateHelpWidgetState();
     void markModified();
-    
+
 private slots:
     void on_awake();
 


### PR DESCRIPTION
Compatibility with version 1.x project files has been restored.

As it turned out, most of the old code for loading older project versions had never been removed from the codebase, so restoring compatibility turned out to be fairly easy.

Loading of both single-window and multi-window XML project files is supported. 

New methods `MainWindow::project()` and `FormDataView::project()` have been added, because when loading a data view for an older version, a script view must be created in parallel—and within an independent serialization function—while view creation is only available within the project object. Need to pass a reference to it through the main window and the data view.

The data view serialization functions had to be moved to a C++ file after all, as class definition issues arose.

Places where old code is present are marked with a comment like `// Version 1.x ...`

Fixes #116.